### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: "library"
   lifecycle: "production"
-  owner: "digibok"
+  owner: "eiet"
   system: "dokumentbestilling"
 ---
 apiVersion: "backstage.io/v1alpha1"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "pdfbox"
+  tags:
+  - "public"
+spec:
+  type: "library"
+  lifecycle: "production"
+  owner: "digibok"
+  system: "dokumentbestilling"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_pdfbox"
+  title: "Security Champion pdfbox"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "DanielBerge"
+  children:
+  - "resource:pdfbox"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "pdfbox"
+  links:
+  - url: "https://github.com/kartverket/pdfbox"
+    title: "pdfbox på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_pdfbox"
+  dependencyOf:
+  - "component:pdfbox"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.