### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @DanielBerge
+/.security/ @DanielBerge

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Eiendom
 product: Dokumentbestilling
 repo_types: [Library]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,31 +8,5 @@ metadata:
 spec:
   type: "library"
   lifecycle: "production"
-  owner: "eiet"
+  owner: "digibok"
   system: "dokumentbestilling"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_pdfbox"
-  title: "Security Champion pdfbox"
-spec:
-  type: "security_champion"
-  parent: "eiendom_security_champions"
-  members:
-  - "DanielBerge"
-  children:
-  - "resource:pdfbox"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "pdfbox"
-  links:
-  - url: "https://github.com/kartverket/pdfbox"
-    title: "pdfbox på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_pdfbox"
-  dependencyOf:
-  - "component:pdfbox"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml